### PR TITLE
Add high contrast theme preset

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,7 +15,9 @@
   --warning: #F59E0B; /* vibrant amber */
   --danger: #EF4444; /* vibrant red */
   --accent: #EC4899; /* vibrant pink */
+  --background: #0F172A;
   --dark-bg: #0F172A; /* dark slate */
+  --surface: #1E293B;
   --dark-card: rgba(30, 41, 59, 0.6); /* frosted glass effect */
   --dark-border: rgba(56, 64, 82, 0.7);
   --text-primary: #F1F5F9;
@@ -23,11 +25,70 @@
   --text-muted: #CBD5E1;
   --text-contrast: #FFFFFF; /* High contrast text */
   --text-warning: #FDE68A;
+  --border: rgba(56, 64, 82, 0.7);
   --accent-gradient: linear-gradient(135deg, var(--primary), var(--secondary));
   --accent-gradient-alt: linear-gradient(135deg, var(--accent), var(--warning));
   --glass-bg: rgba(30, 41, 59, 0.6);
   --glass-border: rgba(56, 64, 82, 0.7);
   --glass-backdrop: blur(12px);
+  --body-gradient: linear-gradient(135deg, #0F172A, #1E293B);
+  --focus-outline: 0 0 0 3px rgba(139, 92, 246, 0.4);
+}
+
+:root[data-theme='light'] {
+  --primary: #7C3AED;
+  --primary-dark: #6D28D9;
+  --secondary: #0284C7;
+  --success: #059669;
+  --warning: #D97706;
+  --danger: #DC2626;
+  --accent: #DB2777;
+  --background: #FFFFFF;
+  --dark-bg: #F8FAFC;
+  --surface: #F1F5F9;
+  --dark-card: rgba(255, 255, 255, 0.85);
+  --dark-border: rgba(148, 163, 184, 0.4);
+  --text-primary: #1E293B;
+  --text-secondary: #475569;
+  --text-muted: #64748B;
+  --text-contrast: #0F172A;
+  --text-warning: #B45309;
+  --border: rgba(148, 163, 184, 0.3);
+  --glass-bg: rgba(255, 255, 255, 0.7);
+  --glass-border: rgba(148, 163, 184, 0.6);
+  --glass-backdrop: blur(18px);
+  --body-gradient: linear-gradient(135deg, #FFFFFF, #E2E8F0);
+  --accent-gradient: linear-gradient(135deg, #7C3AED, #0284C7);
+  --accent-gradient-alt: linear-gradient(135deg, #DB2777, #D97706);
+  --focus-outline: 0 0 0 3px rgba(30, 64, 175, 0.3);
+}
+
+:root[data-theme='highContrast'] {
+  --primary: #FFD60A;
+  --primary-dark: #FFB200;
+  --secondary: #00A3FF;
+  --success: #00E68A;
+  --warning: #FF9E00;
+  --danger: #FF3B3B;
+  --accent: #FF1A75;
+  --background: #000000;
+  --dark-bg: #050505;
+  --surface: #0A0A0A;
+  --dark-card: rgba(15, 15, 15, 0.95);
+  --dark-border: #FFFFFF;
+  --text-primary: #FFFFFF;
+  --text-secondary: #F5F5F5;
+  --text-muted: #CCCCCC;
+  --text-contrast: #000000;
+  --text-warning: #FFE066;
+  --border: #FFFFFF;
+  --glass-bg: rgba(0, 0, 0, 0.92);
+  --glass-border: #FFFFFF;
+  --glass-backdrop: blur(4px);
+  --body-gradient: linear-gradient(135deg, #000000, #050505);
+  --accent-gradient: linear-gradient(135deg, #FFD60A, #00A3FF);
+  --accent-gradient-alt: linear-gradient(135deg, #FF1A75, #FF9E00);
+  --focus-outline: 0 0 0 3px #FFFFFF;
 }
 
 body {
@@ -35,7 +96,7 @@ body {
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: linear-gradient(135deg, #0F172A, #1E293B);
+  background: var(--body-gradient, linear-gradient(135deg, #0F172A, #1E293B));
   min-height: 100vh;
   color: var(--text-primary);
   position: relative;
@@ -1807,6 +1868,13 @@ body::before {
   color: white;
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+}
+
+.theme-btn:focus-visible,
+.apply-theme-btn:focus-visible,
+.reset-theme-btn:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: var(--focus-outline);
 }
 
 .theme-btn.active {

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,5 +1,5 @@
 import React, { memo, useState } from 'react';
-import { Sun, Moon, Palette, Settings } from 'lucide-react';
+import { Sun, Moon, Palette, Settings, Contrast } from 'lucide-react';
 
 const ThemeToggle = memo(({ 
   theme, 
@@ -34,30 +34,43 @@ const ThemeToggle = memo(({
           className={`theme-btn ${theme === 'light' ? 'active' : ''}`}
           onClick={() => setThemeMode('light')}
           title="Light theme"
+          aria-pressed={theme === 'light'}
         >
           <Sun size={16} />
         </button>
-        
+
         <button
           className={`theme-btn ${theme === 'dark' ? 'active' : ''}`}
           onClick={() => setThemeMode('dark')}
           title="Dark theme"
+          aria-pressed={theme === 'dark'}
         >
           <Moon size={16} />
         </button>
-        
+
+        <button
+          className={`theme-btn ${theme === 'highContrast' ? 'active' : ''}`}
+          onClick={() => setThemeMode('highContrast')}
+          title="High contrast theme"
+          aria-pressed={theme === 'highContrast'}
+        >
+          <Contrast size={16} />
+        </button>
+
         <button
           className="theme-btn"
           onClick={toggleTheme}
           title="Toggle theme"
+          aria-pressed="false"
         >
           {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
         </button>
-        
+
         <button
           className="theme-btn"
           onClick={() => setShowCustomTheme(!showCustomTheme)}
           title="Custom theme"
+          aria-expanded={showCustomTheme}
         >
           <Palette size={16} />
         </button>

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,5 +1,107 @@
 import { useState, useEffect, useCallback } from 'react';
 
+const DEFAULT_THEMES = {
+  dark: {
+    name: 'Dark',
+    colors: {
+      primary: '#8B5CF6',
+      primaryDark: '#7C3AED',
+      secondary: '#0EA5E9',
+      success: '#10B981',
+      warning: '#F59E0B',
+      danger: '#EF4444',
+      accent: '#EC4899',
+      background: '#0F172A',
+      darkBg: '#0F172A',
+      surface: '#1E293B',
+      darkCard: 'rgba(30, 41, 59, 0.6)',
+      darkBorder: 'rgba(56, 64, 82, 0.7)',
+      text: '#F1F5F9',
+      textPrimary: '#F1F5F9',
+      textSecondary: '#E2E8F0',
+      textMuted: '#CBD5E1',
+      textContrast: '#FFFFFF',
+      textWarning: '#FDE68A',
+      border: 'rgba(56, 64, 82, 0.7)',
+      glassBg: 'rgba(30, 41, 59, 0.6)',
+      glassBorder: 'rgba(56, 64, 82, 0.7)',
+      glassBackdrop: 'blur(12px)',
+      bodyGradient: 'linear-gradient(135deg, #0F172A, #1E293B)',
+      accentGradient: 'linear-gradient(135deg, #8B5CF6, #0EA5E9)',
+      accentGradientAlt: 'linear-gradient(135deg, #EC4899, #F59E0B)',
+      focusOutline: '0 0 0 3px rgba(139, 92, 246, 0.4)'
+    }
+  },
+  light: {
+    name: 'Light',
+    colors: {
+      primary: '#7C3AED',
+      primaryDark: '#6D28D9',
+      secondary: '#0284C7',
+      success: '#059669',
+      warning: '#D97706',
+      danger: '#DC2626',
+      accent: '#DB2777',
+      background: '#FFFFFF',
+      darkBg: '#F8FAFC',
+      surface: '#F1F5F9',
+      darkCard: 'rgba(255, 255, 255, 0.85)',
+      darkBorder: 'rgba(148, 163, 184, 0.4)',
+      text: '#1E293B',
+      textPrimary: '#1E293B',
+      textSecondary: '#475569',
+      textMuted: '#64748B',
+      textContrast: '#0F172A',
+      textWarning: '#B45309',
+      border: 'rgba(148, 163, 184, 0.3)',
+      glassBg: 'rgba(255, 255, 255, 0.7)',
+      glassBorder: 'rgba(148, 163, 184, 0.6)',
+      glassBackdrop: 'blur(18px)',
+      bodyGradient: 'linear-gradient(135deg, #FFFFFF, #E2E8F0)',
+      accentGradient: 'linear-gradient(135deg, #7C3AED, #0284C7)',
+      accentGradientAlt: 'linear-gradient(135deg, #DB2777, #D97706)',
+      focusOutline: '0 0 0 3px rgba(30, 64, 175, 0.3)'
+    }
+  },
+  highContrast: {
+    name: 'High Contrast',
+    colors: {
+      primary: '#FFD60A',
+      primaryDark: '#FFB200',
+      secondary: '#00A3FF',
+      success: '#00E68A',
+      warning: '#FF9E00',
+      danger: '#FF3B3B',
+      accent: '#FF1A75',
+      background: '#000000',
+      darkBg: '#050505',
+      surface: '#0A0A0A',
+      darkCard: 'rgba(15, 15, 15, 0.95)',
+      darkBorder: '#FFFFFF',
+      text: '#FFFFFF',
+      textPrimary: '#FFFFFF',
+      textSecondary: '#F5F5F5',
+      textMuted: '#CCCCCC',
+      textContrast: '#000000',
+      textWarning: '#FFE066',
+      border: '#FFFFFF',
+      glassBg: 'rgba(0, 0, 0, 0.92)',
+      glassBorder: '#FFFFFF',
+      glassBackdrop: 'blur(4px)',
+      bodyGradient: 'linear-gradient(135deg, #000000, #050505)',
+      accentGradient: 'linear-gradient(135deg, #FFD60A, #00A3FF)',
+      accentGradientAlt: 'linear-gradient(135deg, #FF1A75, #FF9E00)',
+      focusOutline: '0 0 0 3px #FFFFFF'
+    }
+  }
+};
+
+const toCssVarName = (key) =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/\s+/g, '-')
+    .toLowerCase();
+
 // Theme hook for dark/light mode and custom themes
 export const useTheme = () => {
   const [theme, setTheme] = useState('dark');
@@ -34,6 +136,19 @@ export const useTheme = () => {
       localStorage.setItem('aiWorkerCustomTheme', JSON.stringify(customTheme));
     }
   }, [customTheme]);
+
+  const applyDefaultTheme = useCallback((themeKey) => {
+    const root = document.documentElement;
+    const themeData = DEFAULT_THEMES[themeKey] || DEFAULT_THEMES.dark;
+
+    if (themeData?.colors) {
+      Object.entries(themeData.colors).forEach(([key, value]) => {
+        root.style.setProperty(`--${toCssVarName(key)}`, value);
+      });
+    }
+
+    return themeData;
+  }, []);
 
   // Toggle between dark and light theme
   const toggleTheme = useCallback(() => {
@@ -110,10 +225,11 @@ export const useTheme = () => {
     if (!themeData) return;
 
     const root = document.documentElement;
-    
+    root.setAttribute('data-theme', 'custom');
+
     // Apply color variables
     Object.entries(themeData.colors).forEach(([key, value]) => {
-      root.style.setProperty(`--${key}`, value);
+      root.style.setProperty(`--${toCssVarName(key)}`, value);
     });
 
     // Apply font variables
@@ -142,6 +258,19 @@ export const useTheme = () => {
     });
   }, []);
 
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (customTheme) {
+      root.setAttribute('data-theme', 'custom');
+      applyCustomTheme(customTheme);
+      return;
+    }
+
+    root.setAttribute('data-theme', theme);
+    applyDefaultTheme(theme);
+  }, [theme, customTheme, applyCustomTheme, applyDefaultTheme]);
+
   // Reset to default theme
   const resetTheme = useCallback(() => {
     setCustomTheme(null);
@@ -167,45 +296,7 @@ export const useTheme = () => {
       return customTheme;
     }
 
-    // Default themes
-    const themes = {
-      dark: {
-        name: 'Dark',
-        colors: {
-          primary: '#8B5CF6',
-          secondary: '#0EA5E9',
-          success: '#10B981',
-          warning: '#F59E0B',
-          danger: '#EF4444',
-          accent: '#EC4899',
-          background: '#0F172A',
-          surface: '#1E293B',
-          text: '#F1F5F9',
-          textSecondary: '#E2E8F0',
-          textMuted: '#CBD5E1',
-          border: 'rgba(56, 64, 82, 0.7)'
-        }
-      },
-      light: {
-        name: 'Light',
-        colors: {
-          primary: '#7C3AED',
-          secondary: '#0284C7',
-          success: '#059669',
-          warning: '#D97706',
-          danger: '#DC2626',
-          accent: '#DB2777',
-          background: '#FFFFFF',
-          surface: '#F8FAFC',
-          text: '#1E293B',
-          textSecondary: '#475569',
-          textMuted: '#64748B',
-          border: 'rgba(148, 163, 184, 0.3)'
-        }
-      }
-    };
-
-    return themes[theme] || themes.dark;
+    return DEFAULT_THEMES[theme] || DEFAULT_THEMES.dark;
   }, [theme, customTheme]);
 
   return {


### PR DESCRIPTION
## Summary
- add shared default theme definitions including a high contrast preset and sync theme variables to the document root
- update the theme toggle to surface the high contrast option alongside improved accessibility attributes
- adjust global CSS variables and focus styling so the UI responds to the high contrast values

## Testing
- npm run lint
- node <<'NODE' ... (contrast validation)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1700b23c83308fbe069762482c7e)